### PR TITLE
Shadowsocks: Delete Check iptables-mod-tproxy

### DIFF
--- a/files/luci/i18n/shadowsocks.zh-cn.po
+++ b/files/luci/i18n/shadowsocks.zh-cn.po
@@ -111,6 +111,3 @@ msgstr "UDP本地端口"
 
 msgid "UDP-Relay Server"
 msgstr "UDP服务器"
-
-msgid "Unusable - Missing iptables-mod-tproxy"
-msgstr "不可用 - iptables-mod-tproxy 缺失"

--- a/files/luci/model/cbi/shadowsocks.lua
+++ b/files/luci/model/cbi/shadowsocks.lua
@@ -109,13 +109,9 @@ o.default = "nil"
 o.rmempty = false
 
 o = s:option(ListValue, "udp_relay_server", translate("UDP-Relay Server"))
-if is_installed("iptables-mod-tproxy") then
-	o:value("", translate("Disable"))
-	o:value("same", translate("Same as Global Server"))
-	for k, v in pairs(server_table) do o:value(k, v) end
-else
-	o:value("", translate("Unusable - Missing iptables-mod-tproxy"))
-end
+o:value("", translate("Disable"))
+o:value("same", translate("Same as Global Server"))
+for k, v in pairs(server_table) do o:value(k, v) end
 
 -- [[ Servers Setting ]]--
 s = m:section(TypedSection, "servers", translate("Servers Setting"))


### PR DESCRIPTION
iptables-mod-tproxy is remove in https://github.com/shadowsocks/openwrt-shadowsocks/commit/4989d9f3cfa23803cc36420d4ea40de65215cae3  so delete it!